### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNowAlloedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNowAlloedError()
+  response.status(publicErrorObject.statusCode).json(publicErrorObject)
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler
+  }
+}
+
+export default controller;

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,14 +1,14 @@
 import { InternalServerError, MethodNowAlloedError } from "infra/errors";
 
 function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNowAlloedError()
-  response.status(publicErrorObject.statusCode).json(publicErrorObject)
+  const publicErrorObject = new MethodNowAlloedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
 function onErrorHandler(error, request, response) {
   const publicErrorObject = new InternalServerError({
     statusCode: error.statusCode,
-    cause: error
+    cause: error,
   });
 
   console.error(publicErrorObject);
@@ -19,8 +19,8 @@ function onErrorHandler(error, request, response) {
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
-    onError: onErrorHandler
-  }
-}
+    onError: onErrorHandler,
+  },
+};
 
 export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { ServiceError } from './errors'
+import { ServiceError } from "./errors";
 
 async function query(queryObject) {
   let client;
@@ -10,9 +10,9 @@ async function query(queryObject) {
     return result;
   } catch (error) {
     const serviceErrorObject = new ServiceError({
-      message: 'Error occurred in database connection or query',
-      cause: error
-    })
+      message: "Error occurred in database connection or query",
+      cause: error,
+    });
     throw serviceErrorObject;
   } finally {
     await client?.end();

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import pg from "pg";
+import { ServiceError } from './errors'
 
 async function query(queryObject) {
   let client;
@@ -8,9 +9,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\n Erro catched at database.js");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: 'Error occurred in database connection or query',
+      cause: error
+    })
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,12 +1,51 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("An unexpected error occurred.", {
       cause,
     });
 
     this.name = "Internal Server Error.";
     this.action = "Contact your I.T support.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Unavaiable service.", {
+      cause,
+    });
+
+    this.name = "ServiceError";
+    this.action = "Check if service is available.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+export class MethodNowAlloedError extends Error {
+  constructor() {
+    super("Method not allowed for this endpoint.");
+
+    this.name = "MethodNotAllowedError";
+    this.action = "Check if sent HTTP method is valid fo this endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "17.2.4",
         "dotenv-expand": "12.0.3",
         "next": "16.1.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "8.0.4",
         "pg": "8.18.0",
         "react": "19.2.4",
@@ -2498,6 +2499,12 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -8380,6 +8387,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9369,6 +9389,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "17.2.4",
     "dotenv-expand": "12.0.3",
     "next": "16.1.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "8.0.4",
     "pg": "8.18.0",
     "react": "19.2.4",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,49 +1,56 @@
+import { createRouter } from "next-connect"
 import { runner } from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import controller from "infra/controller";
 
-export default async function migrations(request, response) {
-  const allowMethods = ["GET", "POST"];
-  if (!allowMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `"${request.method} not allowed"`,
+const router = createRouter()
+
+router.get(getHandler)
+router.post(postHandler)
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrationOptions = {
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  dryRun: true,
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+    const pendingMigrations = await runner({
+      dbClient,
+      ...defaultMigrationOptions
     });
+    return response.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient.end();
   }
+}
 
+async function postHandler(request, response) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      dryRun: true,
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+    const migratedMigrations = await runner({
+      dbClient,
+      ...defaultMigrationOptions,
+      dryRun: false,
+    });
 
-    if (request.method === "GET") {
-      const pendingMigrations = await runner(defaultMigrationOptions);
-      return response.status(200).json(pendingMigrations);
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
 
-    if (request.method === "POST") {
-      const migratedMigrations = await runner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    return response.status(200).json(migratedMigrations);
   } finally {
     await dbClient.end();
   }

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,13 +1,13 @@
-import { createRouter } from "next-connect"
+import { createRouter } from "next-connect";
 import { runner } from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
 import controller from "infra/controller";
 
-const router = createRouter()
+const router = createRouter();
 
-router.get(getHandler)
-router.post(postHandler)
+router.get(getHandler);
+router.post(postHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -26,7 +26,7 @@ async function getHandler(request, response) {
     dbClient = await database.getNewClient();
     const pendingMigrations = await runner({
       dbClient,
-      ...defaultMigrationOptions
+      ...defaultMigrationOptions,
     });
     return response.status(200).json(pendingMigrations);
   } finally {

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,43 +1,35 @@
+import { createRouter } from "next-connect"
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller";
+const router = createRouter()
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
-    const { query } = database;
+router.get(getHandler)
+export default router.handler(controller.errorHandlers);
 
-    const databaseName = process.env.POSTGRE_DB;
-    const resultServerVersion = await query("SHOW server_version;");
-    const resultMaxConnections = await query("SHOW max_connections;");
-    const resultOpenedConnections = await query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
+  const { query } = database;
 
-    const serverVersion = resultServerVersion.rows[0].server_version;
-    const maxConnections = resultMaxConnections.rows[0].max_connections;
-    const openedConnections = resultOpenedConnections.rowCount;
+  const databaseName = process.env.POSTGRE_DB;
+  const resultServerVersion = await query("SHOW server_version;");
+  const resultMaxConnections = await query("SHOW max_connections;");
+  const resultOpenedConnections = await query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
 
-    return response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: serverVersion,
-          max_connections: parseInt(maxConnections),
-          opened_connections: openedConnections,
-        },
+  const serverVersion = resultServerVersion.rows[0].server_version;
+  const maxConnections = resultMaxConnections.rows[0].max_connections;
+  const openedConnections = resultOpenedConnections.rowCount;
+
+  return response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: serverVersion,
+        max_connections: parseInt(maxConnections),
+        opened_connections: openedConnections,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,9 +1,9 @@
-import { createRouter } from "next-connect"
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
 import controller from "infra/controller";
-const router = createRouter()
+const router = createRouter();
 
-router.get(getHandler)
+router.get(getHandler);
 export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://0.0.0.0:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Method not allowed for this endpoint.",
+        action: "Check if sent HTTP method is valid fo this endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Standardize controllers to endpoints `/migrations` and `/status`.
2. Add two new custom errors: `MethodNotAllowedError` and `ServiceError`.
3. Allow `InternalServerError` injects statusCode in constructor to shape error message. 